### PR TITLE
[codex] Document EMN language extensions

### DIFF
--- a/docs/reference-guide/.nav.yml
+++ b/docs/reference-guide/.nav.yml
@@ -3,4 +3,5 @@ nav:
   - index.md
   - quick-guide.md
   - language-specification.md
+  - language-extensions.md
   - patterns.md

--- a/docs/reference-guide/index.md
+++ b/docs/reference-guide/index.md
@@ -19,6 +19,14 @@ title: Overview
 
     [:octicons-arrow-right-24: Language Specification](language-specification.md)
 
+-   :material-puzzle:{ .lg .middle } __Language Extensions__
+
+    ---
+
+    Read about optional EMN extension schemas and their semantics.
+
+    [:octicons-arrow-right-24: Language Extensions](language-extensions.md)
+
 -   :material-lock-pattern:{ .lg .middle } __Patterns__
 
     ---

--- a/docs/reference-guide/language-extensions.md
+++ b/docs/reference-guide/language-extensions.md
@@ -13,7 +13,7 @@ Tools that do not support a specific extension may preserve the extension data w
 The information completeness check extension documents known and accepted gaps in the information passed along an information flow.
 It is useful when validating whether the target of a flow receives all required information from the source, while still allowing
 modelers to mark selected properties as intentionally ignored.
-The check is only valid for `emn:informationFlowType` elements.
+The check is valid for any `emn:FlowElementType`, including `emn:informationFlowType` and concrete flow node type elements.
 
 #### Namespace
 
@@ -34,6 +34,7 @@ xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL EMN.xsd
 
 The extension root element is `emnic:informationCompleteness`. It can contain an optional
 `emnic:ignoredProperties` element with zero or more `emnic:ignoredProperty` entries.
+The following example shows the extension on an `emn:informationFlowType`.
 
 ```xml
 
@@ -54,10 +55,10 @@ The extension root element is `emnic:informationCompleteness`. It can contain an
 
 #### Semantics
 
-- `emnic:informationCompleteness` defines completeness-check metadata for one information flow type.
+- `emnic:informationCompleteness` defines completeness-check metadata for one EMN flow element type.
 - `emnic:ignoredProperties` groups properties that are excluded from the completeness check.
 - `emnic:ignoredProperty` identifies one ignored property by name and may explain the reason in `comment`.
-- The extension is only valid inside `emn:extensionElements` on `emn:informationFlowType`.
+- The extension is only valid inside `emn:extensionElements` on elements derived from `emn:FlowElementType`.
 
 #### Attributes of `emnic:ignoredProperty`
 

--- a/docs/reference-guide/language-extensions.md
+++ b/docs/reference-guide/language-extensions.md
@@ -1,0 +1,67 @@
+---
+title: Language Extensions
+---
+
+## Extensions
+
+Extensions provide optional namespaces for information that enriches an EMN model without changing the core EMN language.
+Extension elements are placed inside `emn:extensionElements` and are identified by their own XML namespace.
+Tools that do not support a specific extension may preserve the extension data without interpreting it.
+
+### Information Completeness Check
+
+The information completeness check extension documents known and accepted gaps in the information passed along an information flow.
+It is useful when validating whether the target of a flow receives all required information from the source, while still allowing
+modelers to mark selected properties as intentionally ignored.
+The check is only valid for `emn:informationFlowType` elements.
+
+#### Namespace
+
+Documents using this extension declare the `emnic` namespace:
+
+```xml
+xmlns:emnic="https://holixon.io/spec/EMN/20241231/IC"
+```
+
+They may also include the optional schema location for XML validation:
+
+```xml
+xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL EMN.xsd
+                    https://holixon.io/spec/EMN/20241231/IC EMNIC.xsd"
+```
+
+#### Structure
+
+The extension root element is `emnic:informationCompleteness`. It can contain an optional
+`emnic:ignoredProperties` element with zero or more `emnic:ignoredProperty` entries.
+
+```xml
+
+<emn:informationFlowType
+  id="informationFlowType_1"
+  sourceRef="commandType_register_customer"
+  targetRef="eventType_customer_registered">
+  <emn:extensionElements>
+    <emnic:informationCompleteness>
+      <emnic:ignoredProperties>
+        <emnic:ignoredProperty name="name" comment="Not required by the target"/>
+        <emnic:ignoredProperty name="schema" comment="Schema is checked elsewhere"/>
+      </emnic:ignoredProperties>
+    </emnic:informationCompleteness>
+  </emn:extensionElements>
+</emn:informationFlowType>
+```
+
+#### Semantics
+
+- `emnic:informationCompleteness` defines completeness-check metadata for one information flow type.
+- `emnic:ignoredProperties` groups properties that are excluded from the completeness check.
+- `emnic:ignoredProperty` identifies one ignored property by name and may explain the reason in `comment`.
+- The extension is only valid inside `emn:extensionElements` on `emn:informationFlowType`.
+
+#### Attributes of `emnic:ignoredProperty`
+
+| Attribute | Type         | Use      | Description                                      |
+|-----------|--------------|----------|--------------------------------------------------|
+| `name`    | `xsd:string` | required | Name of the property ignored by the check.       |
+| `comment` | `xsd:string` | optional | Reason or note explaining why it is ignored.     |


### PR DESCRIPTION
## Summary

- Add a dedicated Language Extensions reference page.
- Document the optional `emnic` Information Completeness Check extension.
- Add the new page to the reference guide navigation and overview menu.

## Test Plan

- `.venv/bin/mkdocs build --strict`